### PR TITLE
Add configuration docs

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -6,6 +6,7 @@
 * [How It Works](getting-started/how-it-works.md)
 * [Installation](getting-started/installation.md)
 * [Usage](getting-started/usage.md)
+* [Configuration](getting-started/configuration.md)
 * [Callback Events](getting-started/completion-events.md)
 
 ## 🛰 Cool Features

--- a/getting-started/configuration.md
+++ b/getting-started/configuration.md
@@ -31,7 +31,7 @@ $haystack = Haystack::build()
 
 ## Process Automatically
 
-This configuration determines whether Laravel Haystack should automatically queue "Stackable" jobs after each job is processed. If set to `false`, you will need to manually call `$this->nextJob` inside your jobs:
+This configuration determines whether Laravel Haystack should automatically queue `Stackable` jobs after each job is processed. If set to `false`, you will need to manually call `$this->nextJob` inside your jobs:
 
 ```php
 // config/haystack.php

--- a/getting-started/configuration.md
+++ b/getting-started/configuration.md
@@ -61,7 +61,7 @@ class ProcessPodcast implements ShouldQueue, StackableJob
         // Or, with a delay in seconds:
         $this->nextJob($seconds = 15);
         
-        // Or, with a delay with a Carbon instance:
+        // Or, with a delay using a Carbon instance:
         $this->nextJob(now()->addDay());
     }
 }

--- a/getting-started/configuration.md
+++ b/getting-started/configuration.md
@@ -97,7 +97,7 @@ Specifies the duration (in days) for which finished haystacks will be retained. 
 'keep_finished_haystacks_for_days' => 1,
 ```
 
-## Default Database Connection Name
+## Database Connection
 
 Specifies the database connection used to store haystack jobs. The default value is retrieved from the `HAYSTACK_DB_CONNECTION` environment variable, falling back to the default database connection specified in your Laravel configuration (`DB_CONNECTION`).
 

--- a/getting-started/configuration.md
+++ b/getting-started/configuration.md
@@ -1,0 +1,111 @@
+# Configuration
+
+Laravel Haystack provides various configuration options, altering default package behaviour that you may find useful for your application.
+
+## Return All Haystack Data When Finished
+
+When this option is set to `true`, Laravel Haystack will query all the haystack data rows from the database and include them in the `then`/`finally`/`catch` callbacks as a Laravel collection upon completion of the job processing:
+
+```php
+// config/haystack.php
+
+'return_all_haystack_data_when_finished' => true,
+```
+
+```php
+use Illuminate\Support\Collection;
+
+$haystack = Haystack::build()
+   ->addJob(new RecordPodcast)
+   ->then(function (Collection $data) {
+       // ...
+   })
+   ->catch(function (Collection $data) {
+       // ...
+   })
+   ->finally(function (Collection $data) {
+       // ...
+   })
+   ->dispatch();
+```
+
+## Process Automatically
+
+This configuration determines whether Laravel Haystack should automatically queue "Stackable" jobs after each job is processed. If set to `false`, you will need to manually call `$this->nextJob` inside your jobs:
+
+```php
+// config/haystack.php
+
+'process_automatically' => false,
+```
+
+```php
+<?php
+ 
+namespace App\Jobs;
+ 
+use Sammyjo20\LaravelHaystack\Contracts\StackableJob;
+use Sammyjo20\LaravelHaystack\Concerns\Stackable;
+ 
+class ProcessPodcast implements ShouldQueue, StackableJob
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels, Stackable;
+    
+    public function handle()
+    {
+        // ...
+        
+        // Call the next job in the haystack:
+        $this->nextJob();
+        
+        // Or, with a delay in seconds:
+        $this->nextJob($seconds = 15);
+        
+        // Or, with a delay with a Carbon instance:
+        $this->nextJob(now()->addDay());
+    }
+}
+```
+
+## Keep Stale Haystacks for Days
+
+Defines the duration (in days) for which "stale" haystacks are retained. Stale haystacks are those where the controlling job has failed without sending the failure signal to laravel-haystack.
+
+```php
+// config/haystack.php
+
+'keep_stale_haystacks_for_days' => 3,
+```
+
+## Delete Finished Haystacks
+
+Determines whether Laravel Haystack should automatically delete haystacks after they have finished processing. If set to `false`, ensure to use the scheduled command to clean up old finished haystacks.
+
+```php
+// config/haystack.php
+
+'delete_finished_haystacks' => true,
+```
+
+## Keep Finished Haystacks for Days
+
+Specifies the duration (in days) for which finished haystacks will be retained. This is only applicable if `delete_finished_haystacks` is set to `false`.
+
+```php
+// config/haystack.php
+
+'keep_finished_haystacks_for_days' => 1,
+```
+
+## Default Database Connection Name
+
+Specifies the database connection used to store haystack jobs. The default value is retrieved from the `HAYSTACK_DB_CONNECTION` environment variable, falling back to the default database connection specified in your Laravel configuration (`DB_CONNECTION`).
+
+```php
+// config/haystack.php
+
+'db_connection' => env(
+    'HAYSTACK_DB_CONNECTION',
+    env('DB_CONNECTION', 'mysql')
+),
+```


### PR DESCRIPTION
This PR adds a readme for the Haystack configuration file. It's almost the same verbiage as what you have inside of the file itself.

When I was reading the docs I saw mentions to a configuration option but couldn't find references to them in the docs site, specifically on [Deleting Stale Haystacks](https://docs.laravel-haystack.dev/cleanup/deleting-stale-haystacks) when it mentions disabling automatic processing:

> Laravel Haystack will attempt to clean up every job on successful/failed haystacks, however there may be a situation, especially if you have not enabled the **automatic processing**.

This doc will help for searchability, or for those just browsing the site to see what options can be configured without having to dive into the PHP configuration file on the repository itself.

Thanks again for your work on this package! No hard feelings on closure ❤️ 

Let me know if you'd like anything changed/adjusted 👍 